### PR TITLE
staking: move `AbandonOrphanedCoinstakes` to BlockDisconnect

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -213,9 +213,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     static int64_t nLastCoinStakeSearchTime = GetAdjustedTimeSeconds();  // only initialized at startup
 
     if (pwallet) {
-        // flush orphaned coinstakes
-        pwallet->AbandonOrphanedCoinstakes();
-
         // attempt to find a coinstake
         *pfPoSCancel = true;
         pblock->nBits = GetNextTargetRequired(pindexPrev, chainparams.GetConsensus(), true);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1507,6 +1507,9 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
             }
         }
     }
+
+    // Blackcoin - Call to abandon orphaned coinstakes after handling disconnections
+    AbandonOrphanedCoinstakes();
 }
 
 void CWallet::updatedBlockTip()
@@ -3130,9 +3133,6 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
         walletInstance->WalletLogPrintf("m_address_book.size() = %u\n",  walletInstance->m_address_book.size());
     }
-
-    // Flush orphaned coinstakes
-    walletInstance->AbandonOrphanedCoinstakes();
 
     return walletInstance;
 }


### PR DESCRIPTION
The `AbandonOrphanedCoinstakes` function has less impact when run in BlockDisconnect, instead of during staking or walletload. 
